### PR TITLE
ramda was uppercase

### DIFF
--- a/client/components/Settings.jsx
+++ b/client/components/Settings.jsx
@@ -1,7 +1,7 @@
 import React, {Component} from 'react'
 import {connect} from 'react-redux'
 import store, { getKeysAction } from '../store/'
-import {uniq} from 'Ramda'
+import {uniq} from 'ramda'
 
 const uniqueValues = (arr) => {
     const uniqueVals = uniq(arr)


### PR DESCRIPTION
### Assignee Tasks

Heroku had issues with the capitalization of ramda.
